### PR TITLE
dx9.GetChildren() fix

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -51,7 +51,7 @@
     "dx9.GetChildren": {
         "prefix": "dx9.GetChildren",
         "body": [
-            "dx9.GetName(${1:instance})"
+            "dx9.GetChildren(${1:instance})"
         ]
     },
     "dx9.GetPosition": {


### PR DESCRIPTION
dx9.GetChildren() doesn't turn into dx9.GetName() anymore.